### PR TITLE
Unify the read/write arguments

### DIFF
--- a/web-transport-wasm/build.rs
+++ b/web-transport-wasm/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-cfg=web_sys_unstable_apis");
+}

--- a/web-transport-wasm/src/recv.rs
+++ b/web-transport-wasm/src/recv.rs
@@ -24,40 +24,10 @@ impl RecvStream {
         })
     }
 
-    /// Read some data into the provided buffer.
-    ///
-    /// Returns the (non-zero) number of bytes read, or None if the stream is closed.
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, Error> {
-        let chunk = match self.read_chunk(buf.len()).await? {
-            Some(chunk) => chunk,
-            None => return Ok(None),
-        };
-
-        let size = chunk.len();
-        buf[..size].copy_from_slice(&chunk);
-        Ok(Some(size))
-    }
-
-    /// Read some data into the provided buffer.
-    ///
-    /// Returns the (non-zero) number of bytes read, or None if the stream is closed.
-    /// Advances the buffer by the number of bytes read.
-    pub async fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Result<Option<usize>, Error> {
-        let chunk = match self.read_chunk(buf.remaining_mut()).await? {
-            Some(chunk) => chunk,
-            None => return Ok(None),
-        };
-
-        let size = chunk.len();
-        buf.put(chunk);
-
-        Ok(Some(size))
-    }
-
     /// Read the next chunk of data with the provided maximum size.
     ///
     /// This returns a chunk of data instead of copying, which may be more efficient.
-    pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
+    pub async fn read(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
         if !self.buffer.is_empty() {
             let size = cmp::min(max, self.buffer.len());
             let data = self.buffer.split_to(size).freeze();
@@ -76,6 +46,22 @@ impl RecvStream {
         }
 
         Ok(Some(data))
+    }
+
+    /// Read some data into the provided buffer.
+    ///
+    /// Returns the (non-zero) number of bytes read, or None if the stream is closed.
+    /// Advances the buffer by the number of bytes read.
+    pub async fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Result<Option<usize>, Error> {
+        let chunk = match self.read(buf.remaining_mut()).await? {
+            Some(chunk) => chunk,
+            None => return Ok(None),
+        };
+
+        let size = chunk.len();
+        buf.put(chunk);
+
+        Ok(Some(size))
     }
 
     /// Abort reading from the stream with the given reason.

--- a/web-transport-wasm/src/session.rs
+++ b/web-transport-wasm/src/session.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use js_sys::{Object, Reflect, Uint8Array};
 use url::Url;
 use wasm_bindgen_futures::JsFuture;
@@ -81,17 +82,17 @@ impl Session {
     }
 
     /// Send a datagram over the network.
-    pub async fn send_datagram(&mut self, payload: &[u8]) -> Result<(), Error> {
+    pub async fn send_datagram(&mut self, payload: Bytes) -> Result<(), Error> {
         let mut writer = Writer::new(&self.inner.datagrams().writable())?;
         writer.write(&Uint8Array::from(payload.as_ref())).await?;
         Ok(())
     }
 
     /// Receive a datagram over the network.
-    pub async fn recv_datagram(&mut self) -> Result<Vec<u8>, Error> {
+    pub async fn recv_datagram(&mut self) -> Result<Bytes, Error> {
         let mut reader = Reader::new(&self.inner.datagrams().readable())?;
         let data: Uint8Array = reader.read().await?.unwrap_or_default();
-        Ok(data.to_vec())
+        Ok(data.to_vec().into())
     }
 
     /// Close the session with the given error code and reason.

--- a/web-transport/src/quinn.rs
+++ b/web-transport/src/quinn.rs
@@ -96,20 +96,19 @@ impl SendStream {
         Self { inner }
     }
 
-    /// Write *al** of the buffer to the stream, returning the number of bytes written.
+    /// Write *all* of the buffer to the stream.
     pub async fn write(&mut self, buf: &[u8]) -> Result<(), Error> {
         self.inner.write_all(buf).await?;
         Ok(())
     }
 
-    /// Write all of the given buffer to the stream, advancing the internal position.
+    /// Write the given buffer to the stream, advancing the internal position.
     ///
     /// This may be polled to perform partial writes.
     pub async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<(), Error> {
         while buf.has_remaining() {
-            let chunk = buf.chunk();
-            self.write(chunk).await?;
-            buf.advance(chunk.len());
+            let size = self.inner.write(buf.chunk()).await?;
+            buf.advance(size);
         }
 
         Ok(())

--- a/web-transport/src/quinn.rs
+++ b/web-transport/src/quinn.rs
@@ -141,11 +141,15 @@ impl RecvStream {
         Self { inner }
     }
 
-    /// Read some data into the provided buffer.
+    /// Read the next chunk of data with the provided maximum size.
     ///
-    /// The number of bytes read is returned, or None if the stream is closed.
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, Error> {
-        Ok(self.inner.read(buf).await?)
+    /// This returns a chunk of data instead of copying, which may be more efficient.
+    pub async fn read(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
+        Ok(self
+            .inner
+            .read_chunk(max, true)
+            .await?
+            .map(|chunk| chunk.bytes))
     }
 
     /// Read some data into the provided buffer.
@@ -164,17 +168,6 @@ impl RecvStream {
         unsafe { buf.advance_mut(size) };
 
         Ok(Some(size))
-    }
-
-    /// Read the next chunk of data with the provided maximum size.
-    ///
-    /// This returns a chunk of data instead of copying, which may be more efficient.
-    pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
-        Ok(self
-            .inner
-            .read_chunk(max, true)
-            .await?
-            .map(|chunk| chunk.bytes))
     }
 
     /// Send a `STOP_SENDING` QUIC code.

--- a/web-transport/src/wasm.rs
+++ b/web-transport/src/wasm.rs
@@ -54,19 +54,16 @@ impl From<web_transport_wasm::Session> for Session {
 pub struct SendStream(web_transport_wasm::SendStream);
 
 impl SendStream {
-    pub async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+    /// Write all of the given data to the stream.
+    pub async fn write(&mut self, buf: &[u8]) -> Result<(), Error> {
         self.0.write(buf).await
     }
 
     /// Write some of the given buffer to the stream.
-    pub async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<usize, Error> {
+    ///
+    /// Advances the internal position by the number of bytes written.
+    pub async fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Result<(), Error> {
         self.0.write_buf(buf).await
-    }
-
-    /// Write the entire chunk of bytes to the stream.
-    /// More efficient for some implementations, as it avoids a copy
-    pub async fn write_chunk(&mut self, buf: Bytes) -> Result<(), Error> {
-        self.0.write_chunk(buf).await
     }
 
     pub fn set_priority(&mut self, order: i32) {

--- a/web-transport/src/wasm.rs
+++ b/web-transport/src/wasm.rs
@@ -79,18 +79,14 @@ impl SendStream {
 pub struct RecvStream(web_transport_wasm::RecvStream);
 
 impl RecvStream {
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, Error> {
-        self.0.read(buf).await
+    /// Attempt to read a chunk of unbuffered data.
+    pub async fn read(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
+        self.0.read(max).await
     }
 
     /// Attempt to read from the stream into the given buffer.
     pub async fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Result<Option<usize>, Error> {
         self.0.read_buf(buf).await
-    }
-
-    /// Attempt to read a chunk of unbuffered data.
-    pub async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>, Error> {
-        self.0.read_chunk(max).await
     }
 
     /// Send a `STOP_SENDING` QUIC code.


### PR DESCRIPTION
Different from most read/write APIs, but I think this API will help prevent bugs. Rewriting the number of bytes read/written is quite error prone as you need to advance internal state that you might not be prepared to keep.