### PR TITLE
Don't set the N bit for literals.

### DIFF
--- a/web-transport-proto/src/qpack.rs
+++ b/web-transport-proto/src/qpack.rs
@@ -207,7 +207,7 @@ impl Headers {
         +-------------------------------+
         */
 
-        encode_prefix(buf, 4, 0b0111, name);
+        encode_prefix(buf, 4, 0b0101, name);
         encode_prefix(buf, 7, 0b0, value.len());
 
         buf.put_slice(value.as_bytes());
@@ -227,7 +227,7 @@ impl Headers {
         +-------------------------------+
         */
 
-        encode_prefix(buf, 3, 0b00110, name.len());
+        encode_prefix(buf, 3, 0b00100, name.len());
         buf.put_slice(name.as_bytes());
 
         encode_prefix(buf, 7, 0b0, value.len());


### PR DESCRIPTION
This is causing quic-go to reject the connection. It's a bug on their end, but there's no harm in unsetting the bit since it doesn't do anything.

> The following bit, 'N', indicates whether an intermediary is permitted to add this field line to the dynamic table on subsequent hops. When the 'N' bit is set, the encoded field line MUST always be encoded with a literal representation. In particular, when a peer sends a field line that it received represented as a literal field line with the 'N' bit set, it MUST use a literal representation to forward this field line. This bit is intended for protecting field values that are not to be put at risk by compressing them; see [Section 7.1](https://www.rfc-editor.org/rfc/rfc9204.html#probing-dynamic-table-state) for more details.