### PR TITLE
Added Ring feature flag

### DIFF
--- a/web-transport-proto/src/varint.rs
+++ b/web-transport-proto/src/varint.rs
@@ -167,11 +167,11 @@ impl VarInt {
         if x < 2u64.pow(6) {
             w.put_u8(x as u8);
         } else if x < 2u64.pow(14) {
-            w.put_u16(0b01 << 14 | x as u16);
+            w.put_u16((0b01 << 14) | x as u16);
         } else if x < 2u64.pow(30) {
-            w.put_u32(0b10 << 30 | x as u32);
+            w.put_u32((0b10 << 30) | x as u32);
         } else if x < 2u64.pow(62) {
-            w.put_u64(0b11 << 62 | x);
+            w.put_u64((0b11 << 62) | x);
         } else {
             unreachable!("malformed VarInt")
         }

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["quic", "http3", "webtransport"]
 categories = ["network-programming", "web-programming"]
 
 [features]
-default = ["ring"]
+default = ["aws-lc-rs"]
 aws-lc-rs = ["dep:aws-lc-rs"]
 ring = ["dep:ring"]
 

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -11,6 +11,11 @@ edition = "2021"
 keywords = ["quic", "http3", "webtransport"]
 categories = ["network-programming", "web-programming"]
 
+[features]
+default = ["ring"]
+aws-lc-rs = ["dep:aws-lc-rs"]
+ring = ["dep:ring"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -28,7 +33,8 @@ log = "0.4"
 
 rustls = "0.23"
 rustls-native-certs = "0.8"
-aws-lc-rs = "1"
+aws-lc-rs = { version = "1", optional = true }
+ring = { version = "0.17.13", optional = true }
 
 tokio = { version = "1", default-features = false, features = ["macros"] }
 

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["quic", "http3", "webtransport"]
 categories = ["network-programming", "web-programming"]
 
 [features]
-default = ["aws-lc-rs"]
-aws-lc-rs = ["dep:aws-lc-rs"]
-ring = ["dep:ring"]
+default = ["ring"]
+aws-lc-rs = ["dep:aws-lc-rs", "quinn/aws-lc-rs", "rustls/aws-lc-rs"]
+ring = ["dep:ring", "quinn/ring", "rustls/ring"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["quic", "http3", "webtransport"]
 categories = ["network-programming", "web-programming"]
 
 [features]
-default = ["ring"]
+default = ["aws-lc-rs"]
 aws-lc-rs = ["dep:aws-lc-rs", "quinn/aws-lc-rs", "rustls/aws-lc-rs"]
 ring = ["dep:ring", "quinn/ring", "rustls/ring"]
 

--- a/web-transport-quinn/src/client.rs
+++ b/web-transport-quinn/src/client.rs
@@ -28,7 +28,7 @@ pub struct ClientBuilder {
 impl ClientBuilder {
     /// Create a Client builder, which can be used to establish multiple [Session]s.
     pub fn new() -> Self {
-        #[cfg(feature = "aws-lc-rs")]
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
         let provider = rustls::crypto::aws_lc_rs::default_provider();
 
         #[cfg(feature = "ring")]
@@ -97,7 +97,7 @@ impl ClientBuilder {
         certs: Vec<CertificateDer>,
     ) -> Result<Client, ClientError> {
         let hashes = certs.iter().map(|cert| {
-            #[cfg(feature = "aws-lc-rs")]
+            #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
             let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, cert)
                 .as_ref()
                 .to_vec();
@@ -252,7 +252,7 @@ impl ServerCertVerifier for ServerFingerprints {
         _ocsp_response: &[u8],
         _now: rustls::pki_types::UnixTime,
     ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        #[cfg(feature = "aws-lc-rs")]
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
         let cert_hash = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, end_entity);
 
         #[cfg(feature = "ring")]

--- a/web-transport-quinn/src/lib.rs
+++ b/web-transport-quinn/src/lib.rs
@@ -26,6 +26,7 @@
 // External
 mod client;
 mod error;
+mod provider;
 mod recv;
 mod send;
 mod server;
@@ -33,6 +34,7 @@ mod session;
 
 pub use client::*;
 pub use error::*;
+pub(crate) use provider::*;
 pub use recv::*;
 pub use send::*;
 pub use server::*;

--- a/web-transport-quinn/src/provider.rs
+++ b/web-transport-quinn/src/provider.rs
@@ -1,0 +1,27 @@
+use rustls::{crypto::CryptoProvider, pki_types::CertificateDer};
+
+pub(crate) struct Provider;
+
+// Default Crypto Provider `ring`. NOTE : This will be the default even if both `ring` and `aws-lc-rs` feature flags are enabled.
+#[cfg(feature = "ring")]
+impl Provider {
+    pub fn default() -> CryptoProvider {
+        rustls::crypto::ring::default_provider()
+    }
+
+    pub fn sha256(cert: &CertificateDer<'_>) -> ring::digest::Digest {
+        ring::digest::digest(&ring::digest::SHA256, cert)
+    }
+}
+
+// Crypto Provider if and only if `aws-lc-rs` feature flag is enabled
+#[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+impl Provider {
+    pub fn default() -> CryptoProvider {
+        rustls::crypto::aws_lc_rs::default_provider()
+    }
+
+    pub fn sha256(cert: &CertificateDer<'_>) -> aws_lc_rs::digest::Digest {
+        aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, cert)
+    }
+}

--- a/web-transport-quinn/src/server.rs
+++ b/web-transport-quinn/src/server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{CongestionControl, Connect, ServerError, Session, Settings};
+use crate::{CongestionControl, Connect, Provider, ServerError, Session, Settings};
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -58,14 +58,8 @@ impl ServerBuilder {
         chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
     ) -> Result<Server, ServerError> {
-        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
-        let provider = rustls::crypto::aws_lc_rs::default_provider();
-
-        #[cfg(feature = "ring")]
-        let provider = rustls::crypto::ring::default_provider();
-
         // Standard Quinn setup
-        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
+        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(Provider::default()))
             .with_protocol_versions(&[&rustls::version::TLS13])?
             .with_no_client_auth()
             .with_single_cert(chain, key)?;

--- a/web-transport-quinn/src/server.rs
+++ b/web-transport-quinn/src/server.rs
@@ -60,7 +60,7 @@ impl ServerBuilder {
     ) -> Result<Server, ServerError> {
         // Standard Quinn setup
         let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
-            rustls::crypto::aws_lc_rs::default_provider(),
+            rustls::crypto::ring::default_provider(),
         ))
         .with_protocol_versions(&[&rustls::version::TLS13])?
         .with_no_client_auth()

--- a/web-transport-quinn/src/server.rs
+++ b/web-transport-quinn/src/server.rs
@@ -58,13 +58,17 @@ impl ServerBuilder {
         chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
     ) -> Result<Server, ServerError> {
+        #[cfg(feature = "aws-lc-rs")]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+        #[cfg(feature = "ring")]
+        let provider = rustls::crypto::ring::default_provider();
+
         // Standard Quinn setup
-        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
-            rustls::crypto::ring::default_provider(),
-        ))
-        .with_protocol_versions(&[&rustls::version::TLS13])?
-        .with_no_client_auth()
-        .with_single_cert(chain, key)?;
+        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(&[&rustls::version::TLS13])?
+            .with_no_client_auth()
+            .with_single_cert(chain, key)?;
 
         config.alpn_protocols = vec![crate::ALPN.to_vec()]; // this one is important
 

--- a/web-transport-quinn/src/server.rs
+++ b/web-transport-quinn/src/server.rs
@@ -58,7 +58,7 @@ impl ServerBuilder {
         chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
     ) -> Result<Server, ServerError> {
-        #[cfg(feature = "aws-lc-rs")]
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
         let provider = rustls::crypto::aws_lc_rs::default_provider();
 
         #[cfg(feature = "ring")]


### PR DESCRIPTION
This PR does the following, 

1. Filters the grease Setting values on parsing. Also adds Debug derive for better debug output. 
2. Feature flag for `ring` and `aws_lc_rs`. 

Both `ring` and `aws_lcs_rs` are listed as optional dependencies tied to the feature flag. 

Feature flags change the `default_provider()` from rustls and cert digest computation.
