### PR TITLE
fix: completely remove aws-lc when feature is off

### DIFF
--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3"
 url = "2"
 log = "0.4"
 
-rustls = "0.23"
+rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-native-certs = "0.8"
 aws-lc-rs = { version = "1", optional = true }
 ring = { version = "0.17.13", optional = true }


### PR DESCRIPTION
The work in #68 was a good start, but didn't disable the default feature in rustls, so aws-lc was still present in the dependency tree.