### PR TITLE
Feature: Add url query to CONNECT :path request

### DIFF
--- a/web-transport-proto/src/connect.rs
+++ b/web-transport-proto/src/connect.rs
@@ -76,10 +76,7 @@ impl ConnectRequest {
             .get(":authority")
             .ok_or(ConnectError::WrongAuthority)?;
 
-        let path_and_query = match headers.get(":path") {
-            Some(path_and_query) => path_and_query,
-            None => return Err(ConnectError::WrongPath),
-        };
+        let path_and_query = headers.get(":path").ok_or(ConnectError::WrongPath)?;
 
         let method = headers.get(":method");
         match method

--- a/web-transport-proto/src/connect.rs
+++ b/web-transport-proto/src/connect.rs
@@ -107,7 +107,6 @@ impl ConnectRequest {
             .query()
             .map(|query| format!("{}?{}", self.url.path(), query))
             .unwrap_or(self.url.path().to_string());
-
         headers.set(":path", &path_and_query);
         headers.set(":protocol", "webtransport");
 

--- a/web-transport-proto/src/connect.rs
+++ b/web-transport-proto/src/connect.rs
@@ -102,10 +102,12 @@ impl ConnectRequest {
         headers.set(":method", "CONNECT");
         headers.set(":scheme", self.url.scheme());
         headers.set(":authority", self.url.authority());
-        let path_and_query = match self.url.query() {
-            Some(query) => format!("{}?{}", self.url.path(), query),
-            None => self.url.path().to_string(),
-        };
+        let path_and_query = self
+            .url
+            .query()
+            .map(|query| format!("{}?{}", self.url.path(), query))
+            .unwrap_or(self.url.path().to_string());
+
         headers.set(":path", &path_and_query);
         headers.set(":protocol", "webtransport");
 

--- a/web-transport-proto/src/connect.rs
+++ b/web-transport-proto/src/connect.rs
@@ -102,11 +102,10 @@ impl ConnectRequest {
         headers.set(":method", "CONNECT");
         headers.set(":scheme", self.url.scheme());
         headers.set(":authority", self.url.authority());
-        let path_and_query = self
-            .url
-            .query()
-            .map(|query| format!("{}?{}", self.url.path(), query))
-            .unwrap_or(self.url.path().to_string());
+        let path_and_query = match self.url.query() {
+            Some(query) => format!("{}?{}", self.url.path(), query),
+            None => self.url.path().to_string(),
+        };
         headers.set(":path", &path_and_query);
         headers.set(":protocol", "webtransport");
 


### PR DESCRIPTION
🛠️ Feature: Include URL Query in CONNECT :path Header
This pull request ensures that the query component of the URL is included in the :path pseudo-header when initiating a CONNECT request. This aligns with the HTTP/2 and HTTP/3 specifications, where the :path header encompasses both the path and query components of the URL.

📄 Summary of Changes
Modified the construction of the :path header to concatenate the query string, if present, to the path component.

Ensured that the resulting :path accurately represents the full request target, including any query parameters.

🎯 Motivation
Previously, the query component of the URL was omitted from the :path header in CONNECT requests. This omission could lead to incorrect routing or handling by servers expecting the full request target. By including the query, we ensure better compliance with the HTTP specifications and improve interoperability with various server implementations.

🔍 References

https://www.rfc-editor.org/rfc/rfc9114.html

![Screenshot 2025-04-18 at 4 55 49 PM](https://github.com/user-attachments/assets/de7e99bf-ca14-4f51-aec5-a03d520c4405)


