### PR TITLE
fix connecting to ipv6 using quinn backend

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-max_line_length = 120
+max_line_length = 100
 
 [*.md]
 trim_trailing_whitespace = false

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.7.2"
+version = "0.7.1"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/web-transport-wasm/Cargo.toml
+++ b/web-transport-wasm/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 keywords = ["quic", "http3", "webtransport"]
 categories = ["network-programming", "web-programming"]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg=web_sys_unstable_apis"]
+
 [dependencies]
 bytes = "1"
 js-sys = "0.3.76"
@@ -19,9 +22,6 @@ url = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-streams = "0.1.2"
-
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg=web_sys_unstable_apis"]
 
 [dependencies.web-sys]
 version = "0.3.76"

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -17,8 +17,8 @@ bytes = "1"
 thiserror = "2"
 url = "2"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-web-transport-wasm = { version = "0.5.0", path = "../web-transport-wasm" }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 web-transport-quinn = { version = "0.7.1", path = "../web-transport-quinn" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-transport-wasm = { version = "0.5.0", path = "../web-transport-wasm" }

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.3"
+version = "0.9.2"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -21,4 +21,4 @@ url = "2"
 web-transport-wasm = { version = "0.5.0", path = "../web-transport-wasm" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-web-transport-quinn = { version = "0.7.2", path = "../web-transport-quinn" }
+web-transport-quinn = { version = "0.7.1", path = "../web-transport-quinn" }

--- a/web-transport/Cargo.toml
+++ b/web-transport/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/web-transport-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -21,4 +21,4 @@ url = "2"
 web-transport-wasm = { version = "0.5.0", path = "../web-transport-wasm" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-web-transport-quinn = { version = "0.7.1", path = "../web-transport-quinn" }
+web-transport-quinn = { version = "0.7.2", path = "../web-transport-quinn" }


### PR DESCRIPTION
currently it is not possible to connect to an Ipv6 address using quinn



the reason for this is the the Url crate converts the Ipv6 host enum variant to a string encompassed in `[]` i.e. `[::1]` however during domain name resolution it is not recognized as an ipv6 due to the `[]` and instead tries to look it up as if it was a domain which of course fails.

here is the [code](https://github.com/servo/rust-url/blob/68f151c01682d620605b749b61684084150a6c41/url/src/host.rs#L181) in Url that adds `[]`
```rust
Host::Ipv6(ref addr) => {
    f.write_str("[")?;
    write_ipv6(addr, f)?;
    f.write_str("]")
}
```
they [write](https://github.com/servo/rust-url/blob/68f151c01682d620605b749b61684084150a6c41/url/src/host.rs#L59) they do this because of [RFC 5952 *A Recommendation for IPv6 Address Text Representation*](https://tools.ietf.org/html/rfc5952)

that this causes problems is a [known issue](https://github.com/servo/rust-url/issues/770)

[here is the code in tokio](https://github.com/tokio-rs/tokio/blob/ab8d7b82a1252b41dc072f641befb6d2afcb3373/tokio/src/net/addr.rs#L210) that is called by this crate that handles name resolution and tries to parse the ipv6 and fails because of the `[]`


as it is unlikely that either tokio or Url will fix this representation incompatibility i would suggest that the appropriate solution is to never convert to str and then reparse and instead only do name resolution if we are not dealing with an IP

As the host string is also passed to the connect_with function i do not know if it is appropriate to keep the `[]` so i am not changing that.